### PR TITLE
Seem lack of source path 'abc'. Just comment line#12 in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif ()
 
 set(ABC_USE_NAMESPACE abc)
 set(dals_include ${PROJECT_SOURCE_DIR}/include/)
-add_subdirectory(abc EXCLUDE_FROM_ALL)
+#add_subdirectory(abc EXCLUDE_FROM_ALL)
 add_subdirectory(abc-plus)
 
 add_definitions(-DPROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ endif ()
 
 set(ABC_USE_NAMESPACE abc)
 set(dals_include ${PROJECT_SOURCE_DIR}/include/)
-#add_subdirectory(abc EXCLUDE_FROM_ALL)
+add_subdirectory(abc EXCLUDE_FROM_ALL)
 add_subdirectory(abc-plus)
 
 add_definitions(-DPROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")

--- a/abc-plus/src/visual.cpp
+++ b/abc-plus/src/visual.cpp
@@ -65,7 +65,7 @@ namespace abc {
 
         // transform logic functions from BDD to SOP
         if ((fHasBdds = Abc_NtkIsBddLogic(pNtk))) {
-            if (!Abc_NtkBddToSop(pNtk, -1, ABC_INFINITY)) {
+            if (!Abc_NtkBddToSop(pNtk, -1, ABC_INFINITY, 1)) {
                 printf("Io_WriteDotNtk(): Converting to SOPs has failed.\n");
                 return;
             }


### PR DESCRIPTION
'cmake' will pass w/o error.
But make will fail with error, seem lack of some source files, which is /abc/abc*

Kindly please help make some comments on this issue, or just sharing the missing source file will be appreciated.

> yangjie@yangjiedeMacBook-Pro DALS % make
> [  8%] Building CXX object abc-plus/CMakeFiles/abc_plus.dir/src/framework.cpp.o
> warning: unknown warning option '-Wno-unused-but-set-variable'; did you mean '-Wno-unused-const-variable'? [-Wunknown-warning-option]
> In file included from /Users/yangjie/DALS/abc-plus/src/framework.cpp:10:
> In file included from /Users/yangjie/DALS/abc-plus/include/framework.h:14:
> /Users/yangjie/DALS/abc-plus/include/abc_api.h:16:10: **fatal error: 'base/abc/abc.h' file not found**
> #include <base/abc/abc.h>
>          ^~~~~~~~~~~~~~~~
> 1 warning and 1 error generated.
> make[2]: *** [abc-plus/CMakeFiles/abc_plus.dir/src/framework.cpp.o] Error 1
> make[1]: *** [abc-plus/CMakeFiles/abc_plus.dir/all] Error 2
> make: *** [all] Error 2